### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Files for Docker to ignore when building the image
+.git/
+.github/
+.gitignore
+.dockerignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use image with ruby, Node.js, npm, and yarn
+FROM timbru31/ruby-node:latest
+
+# Grab dependencies
+WORKDIR /app
+COPY . /app
+
+# Install nodemon and webrick
+RUN npm install -g nodemon
+RUN bundle add webrick
+
+# Expose port 4000
+EXPOSE 4000
+
+# Start jekyll server
+CMD ["bundle", "exec", "jekyll", "s", "-l", "-o", "-H", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ npm start
 ```
 ---
 
+### Want to set this up on **Docker**?
+- Clone this **Repository** using **Git**<br>
+``` git
+git clone https://harsh98trivedi/Links
+```
+- Go to the project directory
+```bash
+cd links
+```
+- Edit the **_config.yml**
+- Fill the available details accordingly
+- Commit the changes
+- Build the **Docker** image
+```bash
+docker build -t links .
+```
+- Run the **Docker** container
+```bash
+docker run -d -p 4000:4000 --name links links
+```
+- Open the browser and go to **links-ip:4000**. You should see your **links** site up and running!
+
+> Note: Whenever you make changes to the **_config.yml** file, you need to rebuild the **Docker** image and recreate the container to see the changes.
+
 ## Content Credits
 - [Cover Image](https://source.unsplash.com/)
 - [Font Awesome](https://fontawesome.com/)


### PR DESCRIPTION
Hello! I recently discovered this repo and was impressed! I then noticed the issue asking for Docker support, so I thought I'd go ahead and add that. 

This PR adds support for Docker in the form of a Dockerfile. This allows people to manually build the image and create the Docker container themselves. It could also be used in the future if you decide to add the project to Docker Hub.

To build the Docker image, I chose an image that already had most of the requirements installed, [ruby-node](https://hub.docker.com/r/timbru31/ruby-node) (Since it comes with `Ruby`, `Node.js`, `npm`, and `yarn`). The rest of the required files are then copied into the image (except the ones specified in `.dockerignore`), and 2 more dependencies are installed (`nodemon` and `webrick`). Port 4000 is also exposed in order to view the site. In order to make the server work in Docker, I had to modify the command from `npm start` to `bundle exec jekyll s -l -o -H 0.0.0.0`. This basically changed the host from `localhost` to all IP addresses so that the links server would be accessible outside of the Docker container.

I also added all the Docker commands and instructions to the readme =)