### PR TITLE
Update docker run command with file passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ docker build -t links .
 ```
 - Run the **Docker** container
 ```bash
-docker run -d -p 4000:4000 --name links links
+docker run -d -p 4000:4000 -v /absolute/path/to/_config.yml:/app/_config.yml --name links links
 ```
 - Open the browser and go to **links-ip:4000**. You should see your **links** site up and running!
 
-> Note: Whenever you make changes to the **_config.yml** file, you need to rebuild the **Docker** image and recreate the container to see the changes.
+> Note: Whenever you make changes to the **_config.yml** file, you need to stop and remove the **Docker** container, then recreate it:
+```bash
+docker stop links && docker rm links && docker run -d -p 4000:4000 -v /absolute/path/to/_config.yml:/app/_config.yml --name links links
+```
+```
 
 ## Content Credits
 - [Cover Image](https://source.unsplash.com/)


### PR DESCRIPTION
This allows the user to passthrough their `_config.yml` to the docker container at the `run` command, instead of depending on the file being added during the image build. Because passed through files overwrite existing ones, the default `_config.yml` will be overwritten if the user passes a file through when starting the docker container. Then all the user needs to do is recreate the docker container whenever they make changes to `_config.yml` instead of rebuilding the image every time.