### PR TITLE
Don't enable live reload in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN bundle add webrick
 EXPOSE 4000
 
 # Start jekyll server
-CMD ["bundle", "exec", "jekyll", "s", "-l", "-o", "-H", "0.0.0.0"]
+CMD ["bundle", "exec", "jekyll", "s", "-o", "-H", "0.0.0.0"]


### PR DESCRIPTION
This removes the `-l` flag from the Docker command line. Live reload is only intended for development and can lead to extremely long load times (>100s) when the live reload port is not accessible (e.g. when proxying through Cloudflare)