### PR TITLE
Docker update site on restart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 .gitignore
 .dockerignore
 README.md
+config/
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN bundle add webrick
 EXPOSE 4000
 
 # Start jekyll server
-CMD ["bundle", "exec", "jekyll", "s", "-o", "-H", "0.0.0.0"]
+CMD ["bundle", "exec", "jekyll", "s", "-o", "-H", "0.0.0.0", "--config", "config/_config.yml"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Beautiful Jekyll Theme For Links
 
 ### Up and Running
 - Fork this [Repository](https://github.com/harsh98trivedi/Links)<br>
-- Edit the **_config.yml**
+- Edit the **_config.yml** in the **config** directory
 - Fill the available details accordingly
 - Commit the changes
 
@@ -40,25 +40,41 @@ git clone https://github.com/[USERNAME]/Links
 cd links
 ```
 - Install **Links** with **npm**
-``` bash
-npm start
+```bash
+npm install
 ```
+- Run the **Jekyll** server
+```bash
+bundle exec jekyll serve --config config/_config.yml
+```
+- Open the browser and go to **http://localhost:4000**. You should see your **links** site up and running!
 ---
 
 ### Want to set this up on **Docker**?
 View repository on [Docker Hub](https://hub.docker.com/r/harsh98trivedi/links)
-- Edit your **_config.yml**
-- Fill in the available details accordingly
-- Run the **Docker** container:
-```bash
-docker run -d -p 4000:4000 -v /absolute/path/to/_config.yml:/app/_config.yml --name links harsh98trivedi/links:latest
-```
-- Open the browser and go to **links-ip:4000**. You should see your **links** site up and running!
 
-> Note: Whenever you make changes to the **_config.yml** file, you need to stop and remove the **Docker** container, then recreate it:
+We have a premade **Docker Compose** file for you to get started, all you need to do is:
+- Edit the **_config.yml** in the **config** directory
+- Fill in the available details accordingly
+- Run the **Docker** container using **Docker Compose**:
 ```bash
-docker stop links && docker rm links && docker run -d -p 4000:4000 -v /absolute/path/to/_config.yml:/app/_config.yml --name links harsh98trivedi/links:latest
+docker compose up -d
 ```
+- Open the browser and go to **http://localhost:4000**. You should see your **links** site up and running!
+
+> Note: Whenever you make changes to the **_config.yml** file, you need to restart the container for the changes to take effect. You can do so by running:
+```bash
+docker restart links
+```
+If you wish to build the image yourself, uncomment the **build** line in the **docker-compose.yml** file and comment out the **image** line. Then run the following command:
+```bash
+docker compose build
+```
+Then run the container using:
+```bash
+docker compose up -d
+```
+---
 
 ## Content Credits
 - [Cover Image](https://source.unsplash.com/)

--- a/config/_config.yml
+++ b/config/_config.yml
@@ -265,17 +265,17 @@ compress_html:
 
 # Exclude
 exclude:
-  - .sass-cache/
-  - .jekyll-cache/
-  - gemfiles/
-  - Gemfile
-  - Gemfile.lock
-  - node_modules/
-  - vendor/bundle/
-  - vendor/cache/
-  - vendor/gems/
-  - vendor/ruby/
-  - Icon
+  - ../.sass-cache/
+  - ../.jekyll-cache/
+  - ../gemfiles/
+  - ../Gemfile
+  - ../Gemfile.lock
+  - ../node_modules/
+  - ../vendor/bundle/
+  - ../vendor/cache/
+  - ../vendor/gems/
+  - ../vendor/ruby/
+  - ../Icon
 
 # Base URL
 # baseurl: /links

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+services:
+  links:
+    container_name: links
+    # build: . # Uncomment this line and comment the image line below to build the image locally
+    image: harsh98trivedi/links:latest
+    volumes:
+      - ./config:/app/config
+    restart: unless-stopped
+    ports:
+      - 4000:4000


### PR DESCRIPTION
In response to https://github.com/harsh98trivedi/links/issues/3#issuecomment-1256841778, this PR makes it so that whenever the `_config.yml` file is updated, Docker pulls the newest version on restart. This is accomplished by creating a new directory called `config`, which contains the `_config.yml` file. We can then bind mount the volume `config` with Docker so that whenever `_config.yml` is changed the changes are immediately reflected in the Docker container.

However, because Jekyll is a static site generator, the changes to `_config.yml` won't update the site immediately, so a restart of the Docker container is needed. This is the expected behavior of Jekyll.

In order to make Docker easier, a `docker-compose.yml` file was created, which vastly cuts down on the commands and should make things much simpler.

The readme was also updated to reflect these changes. Because the config file is stored in a directory, the command `npm start` was no longer sufficient since we need to tell Jekyll where the config file is, so that has been updated. The docker section has also been updated with docker-compose commands, as well as instructions to build and run the docker image locally.